### PR TITLE
(GH-24) Support large file uploads

### DIFF
--- a/UnitTests/FileScanTests.cs
+++ b/UnitTests/FileScanTests.cs
@@ -69,7 +69,7 @@ namespace UnitTests
 
         [TestMethod]
         [ExpectedException(typeof(SizeLimitException))]
-        public void ScanLargeFile()
+        public void ScanLargeFileOverSizeLimits()
         {
             //We expect it to throw a SizeLimitException because the file is above the legal limit
             _virusTotal.ScanFile(new byte[_virusTotal.FileSizeLimit + 1], "VirusTotal.NET-Test.txt");
@@ -80,6 +80,30 @@ namespace UnitTests
         {
             _virusTotal.Timeout = 1000 * 250;
             _virusTotal.ScanFile(new byte[_virusTotal.FileSizeLimit], "VirusTotal.NET-Test.txt");
+        }
+
+        [TestMethod]
+        public void ScanLargeFileWithoutSizeLimitRestrictions()
+        {
+            _virusTotal.RestrictSizeLimits = false;
+            _virusTotal.FollowRedirects = true;
+
+            try
+            {
+                // We expect it to ask for the larger size because the file is above the legal limit
+                // to test this without access denied, the API key must be allowed to upload larger files
+                _virusTotal.ScanFile(new byte[_virusTotal.FileSizeLimit + 1], "VirusTotal.NET-Test.txt");
+            }
+            catch (Exception)
+            {
+                throw;
+            }
+            finally
+            {
+                _virusTotal.RestrictSizeLimits = true;
+                _virusTotal.FollowRedirects = false;
+            }
+
         }
     }
 }

--- a/VirusTotal.NET/Objects/LargeFileUpload.cs
+++ b/VirusTotal.NET/Objects/LargeFileUpload.cs
@@ -1,0 +1,13 @@
+namespace VirusTotalNET.Objects
+{
+    /// <summary>
+    /// For files bigger than 32MB, we need a special Url to upload them
+    /// </summary>
+    public class LargeFileUpload
+    {
+        /// <summary>
+        /// The special upload url to be used
+        /// </summary>
+        public string UploadUrl { get; set; } 
+    }
+}

--- a/VirusTotal.NET/VirusTotal.NET.csproj
+++ b/VirusTotal.NET/VirusTotal.NET.csproj
@@ -62,6 +62,7 @@
     <Compile Include="Exceptions\SizeLimitException.cs" />
     <Compile Include="HashHelper.cs" />
     <Compile Include="Exceptions\InvalidResourceException.cs" />
+    <Compile Include="Objects\LargeFileUpload.cs" />
     <Compile Include="Objects\IPReport.cs" />
     <Compile Include="Objects\DomainReport.cs" />
     <Compile Include="Objects\IPReportResponseCode.cs" />


### PR DESCRIPTION
If the file is above the public api size limit and the user has
selected `RestrictSizeLimits = false`, then attempt to use the upload
url. If the user does not have access, they will receive the regular
access denied message:  "AccessDeniedException: You don't have access to
the service. Make sure your API key is working correctly."

If the user does have access, it will allow the large file to be
uploaded using the private API url. Since the base url is
different, override the RestClient with a large upload RestClient.

Fixes #24
