### PR TITLE
 Updated YearMonthDayConverter

### DIFF
--- a/VirusTotal.NET/DateTimeParsers/YearMonthDayConverter.cs
+++ b/VirusTotal.NET/DateTimeParsers/YearMonthDayConverter.cs
@@ -24,6 +24,9 @@ namespace VirusTotalNET.DateTimeParsers
             if (reader.Value == null)
                 return DateTime.MinValue;
 
+            if (string.IsNullOrEmpty(reader.Value as string ))
+                return DateTime.MinValue;
+                
             if (!(reader.Value is string stringVal))
                 throw new InvalidDateTimeException("Invalid date/time from VirusTotal. Tried to parse: " + reader.Value);
 


### PR DESCRIPTION
For some reasons, I was getting Invalid date/time from VirusTotal. After digging out, it was revealed that ReadJson was returning an empty response. I later fixed it. and publishing it for betterment of the project.