### PR TITLE
[FIX] - An ability to get url report by scan id in batch method

### DIFF
--- a/src/VirusTotalNet/VirusTotal.cs
+++ b/src/VirusTotalNet/VirusTotal.cs
@@ -599,7 +599,7 @@ public class VirusTotal
     /// <param name="scanIfNoReport">Set to true if you wish VirusTotal to scan the URLs if it is not present in the database.</param>
     public Task<IEnumerable<UrlReport>> GetUrlReportsAsync(IEnumerable<string> urls, bool scanIfNoReport = false)
     {
-        urls = ResourcesHelper.ValidateResourcea(urls, ResourceType.URL);
+        urls = ResourcesHelper.ValidateResourcea(urls, ResourceType.URL | ResourceType.ScanId);
 
         string[] urlCast = urls as string[] ?? urls.ToArray();
 


### PR DESCRIPTION
Hello.
The current implementation of the batch method for getting URL reports does not allow to pass scan ids as an argument, although the API allows it. 
Fixes in the pull request.